### PR TITLE
Add box metadata, lowerbound fitting model, and further extend interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,9 @@ version = "0.1.0"
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 BlossomV = "6c721016-9dae-5d90-abf6-67daaccb2332"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Parametron = "41fac6d6-0ffa-5bcc-b863-17dd4947be41"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
@@ -15,3 +17,7 @@ julia = "0.7, 1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
+
+[targets]
+test = ["Test", "GLPK"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,17 @@
+name = "CoordinateSplittingPTrees"
+uuid = "768c9593-c1e5-5107-8576-9ed3f4373482"
+authors = ["Tim Holy <tim.holy@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+BlossomV = "6c721016-9dae-5d90-abf6-67daaccb2332"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[compat]
+julia = "0.7, 1.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/CoordinateSplittingPTrees.jl
+++ b/src/CoordinateSplittingPTrees.jl
@@ -3,6 +3,9 @@ module CoordinateSplittingPTrees
 using LinearAlgebra, SparseArrays
 using AbstractTrees  # for display of tree structures
 import BlossomV      # we use matching to select dimension-pairs (see cs2.jl)
+using DataStructures # for PriorityQueue
+import Parametron    # for solving the lower-bound model. `import` prevents a conflict with Parametron.value
+using Parametron: Model, Variable, Parameter, Minimize, @expression, @constraint, @objective, solve!
 
 export Box, World
 export position, boxbounds, meta, value, addpoint!

--- a/src/CoordinateSplittingPTrees.jl
+++ b/src/CoordinateSplittingPTrees.jl
@@ -10,7 +10,7 @@ using Parametron: Model, Variable, Parameter, Minimize, @expression, @constraint
 export Box, World
 export position, boxbounds, meta, value, addpoint!
 export getroot, getleaf, find_leaf_at, degree, isroot, isleaf, chaintop, iscomplete
-export leaves, splits, chain, splitprint, splitprint_colored, print_tree
+export leaves, splits, chain, splitprint, splitprint_colored, print_tree, print_metabox
 
 include("types.jl")
 include("tree.jl")

--- a/src/cs2.jl
+++ b/src/cs2.jl
@@ -473,10 +473,8 @@ function lowerbound_model(f::Function, box::Box, optimizer, m::Integer=2*ndims(b
             position!(x, flag, box)
             insertrow!(X, X2, Δf, irow+=1, box)
         end
-        # Zero the diagonal of Q so that the NaNs do not poison calculation of the residual
-        for i = 1:n
-            Q[i,i] = 0
-        end
+        # Zero the NaNs so they don't poison Δf
+        nanzero!(Q)
         # From Δf subtract off everything except the gradient term and the diagonal of Q
         mul!(XQX, X, Q)
         XQX .*= X

--- a/src/cs2.jl
+++ b/src/cs2.jl
@@ -24,7 +24,7 @@ function choose_dimensions(box::Box{2})
     # has only one unseen pairing left. Allowing only unseen pairings,
     # we then construct a maximal matching
     # (https://en.wikipedia.org/wiki/Matching_(graph_theory))
-    neven = n + (isodd(n) ? 1 : 0)
+    neven = n + isodd(n)
     agesentinel = typemax(Int)            # this value signals "never seen"
     age = fill(agesentinel, neven, neven) # recency of edge, younger is "worse"
     for i = 1:neven

--- a/src/cs2.jl
+++ b/src/cs2.jl
@@ -382,6 +382,94 @@ end
 
 fit_quadratic_gdiag!(Q, box::Box{2}, b=position(box); skip::Int=0) =
     fit_quadratic_gdiag!(value, Q, box, b; skip=skip)
+
+### Lower-bound model
+# Fit a model for which the observed function values are a lower bound for the model values
+
+function lowerbound_model(f::Function, box::Box, optimizer, m::Integer=3*ndims(box)+1)
+    n = ndims(box)
+    c = f(box)
+    # Keep track of the points incorporated into the fit
+    pq = PriorityQueue{typeof(box),typeof(c)}()
+    function maybe_enqueue(box, val)
+        leaf = getleaf(box)
+        if !haskey(pq, leaf)
+            enqueue!(pq, leaf, val)
+        end
+        nothing
+    end
+    # Allocate storage for the model coefficients and anything needed by `updater`
+    Q = allocate_coefficients_p(n, box)
+    g = similar(Q, n)
+    x = position(box)
+    xbx = similar(x)
+    flag = similar(x, Bool)
+    X = similar(x, m, n)
+    XQX = similar(X)
+    X2 = similar(X)
+    Δf = Vector{typeof(c)}(undef, m)
+    # Perform all box-specific setup (a box `bx` will be passed to this before solving the model)
+    # The end results are `X`, which stores displacements from the base point in its columns,
+    # and Δf, which stores the residual value that should ideally be fit by the gradient and the
+    # diagonal of the Hessian.
+    function updater(bx)
+        empty!(pq)
+        c = f(bx)
+        position!(xbx, flag, bx)
+        iter = splits(bx)
+        state = skipsplits(iter, 0)
+        coefficients_p!(f, Q, bx, iter, state, maybe_enqueue)
+        # If we didn't visit m boxes, continue traversing the tree until we get enough
+        while length(pq) < m
+            split, state = iterate(iter, state)
+            for ichild = 0:maxchildren(box)-1
+                child = getchild(split, ichild)
+                maybe_enqueue(child, f(child))
+            end
+        end
+        # Zero the diagonal of Q so that the NaNs do not poison calculation of the residual
+        for i = 1:n
+            Q[i,i] = 0
+        end
+        for j = 1:m
+            box = dequeue!(pq)
+            position!(x, flag, box)
+            X[j,:] .= x .- xbx
+            Δf[j] = value(box)
+        end
+        # From Δf subtract off everything except the gradient term and the diagonal of Q
+        mul!(XQX, X, Q)
+        XQX .*= X
+        Δf .-= c .+ vec(sum(XQX; dims=2)) ./ 2
+        X2 .= X.^2 ./ 2
+        true  # return upon success
+    end
+    # Set up the solver
+    model = Model(optimizer)
+    g = [Variable(model) for _ = 1:n]
+    d = [Variable(model) for _ = 1:n]
+    Xparam = Parameter(identity, X, model)
+    X2param = Parameter(identity, X2, model)
+    Δfp = Parameter(identity, Δf, model)
+    pred = @expression Xparam*g + X2param*d
+    @constraint(model, pred >= Δfp)
+    @objective(model, Minimize, sum(pred))
+    return updater, model, g, d, Q
+end
+lowerbound_model(box::Box, optimizer, m::Integer=3*ndims(box)+1) = lowerbound_model(value, box, optimizer, m)
+
+function fit_quadratic_lowerbound!(Q, updater, model, g, d, box::Box{2}, b=position(box))
+    updater(box)
+    solve!(model)
+    gv, dv = Parametron.value.(model, g), Parametron.value.(model, d)
+    for i in axes(Q, 1)
+        Q[i,i] = dv[i]
+    end
+    return value(box), gv, Q, b
+end
+
+### Incremental Gaussian Elimination utilities
+
 function Base.insert!(ige::IGE{T}, x::AbstractVector, newrhs; canswap::Bool=true) where T
     @inline myapprox(x, y, rtol) = (x == y) | (abs(x-y) < rtol*(abs(x) + abs(y)))
     rtol = 1000*eps(T)

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -552,6 +552,8 @@ end
 Base.length(iter::Union{Box,CSpTreeIterator}) = _length(iter)
 Base.length(iter::Iterators.Filter{F,I}) where {F,I<:Union{Box,CSpTreeIterator}} =
     _length(iter)
+Base.length(iter::Iterators.Filter{F,I}) where {F,I<:Iterators.Filter{F2,I2}} where {F2,I2<:Box} =
+    _length(iter)
 
 function _length(iter)
     len = 0

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -59,6 +59,7 @@ function get_allparents(box)
     allparents
 end
 
+print_metabox(io::IO, box::Box) = print(io, box, " with metadata ", box.metabox)
 
 ### Geometry
 

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -214,6 +214,13 @@ function boxbounds!(bbs, lfilled, ufilled, box::Box)
     bbs
 end
 
+function Base.in(xs::AbstractVector, box::Box)
+    for (bb, x) in zip(boxbounds(box), xs)
+        bb[1] <= x <= bb[2] || return false
+    end
+    return true
+end
+
 """
     nc = ncollinear(box, top=getroot(box))
 
@@ -270,6 +277,9 @@ function epswidth(bb::Tuple{T,T}) where T<:AbstractFloat
     return max(w1, w2)
 end
 epswidth(bb::Tuple{Real,Real}) = epswidth(Float64.(bb))
+
+# 10*eps is pretty arbitrary, but not unreasonable
+splittable(bb::Tuple{Real,Real}) = bb[2] - bb[1] > 10*epswidth(bb)
 
 ### Traversal
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -183,23 +183,26 @@ function Base.show(io::IO, split::Split)
     print(io, " along $(split.dims) at $(split.xs))")
 end
 
-mutable struct Box{p,T,M,L,P}
+mutable struct Box{p,T,M,L,P,MB}
     world::World{T,P,M}      # the overall problem domain
-    parent::Box{p,T,M,L,P}   # the node above this one
+    parent::Box{p,T,M,L,P,MB}   # the node above this one
     childindex::UInt8        # which of parent's children is this? (0=self)
-    split::Split{p,T,M,Box{p,T,M,L,P},L}  # undefined if this box is a leaf node
+    split::Split{p,T,M,Box{p,T,M,L,P,MB},L}  # undefined if this box is a leaf node
+    metabox::MB
 
-    function Box{p,T,M,L,P}(world::World{T,P,M}) where {p,T,M,L,P}
+    function Box{p,T,M,L,P,MB}(world::World{T,P,M}, metabox) where {p,T,M,L,P,MB}
         p > 8 && error("degree must be less than or equal to 8 (change childindex::UInt8 for p>8)")
-        root = new{p,T,M,L,P}(world)
+        root = new{p,T,M,L,P,MB}(world)
         root.parent = root
         root.childindex = 0
+        root.metabox = metabox
         return root
     end
 
-    function Box{p,T,M,L,P}(parent::Box{p,T,M,L,P}, splitdims::NTuple{p,Integer}, xs::NTuple{p,Real}, metas::NTuple{L,M}) where {p,T,M,L,P}
-        function box(parent::Box{p,T,M,L,P}, childindex::Integer) where {p,T,M,L,P}
-            return new{p,T,M,L,P}(parent.world, parent, childindex)
+    function Box{p,T,M,L,P,MB}(parent::Box{p,T,M,L,P,MB}, splitdims::NTuple{p,Integer},
+                               xs::NTuple{p,Real}, metas::NTuple{L,M}) where {p,T,M,L,P,MB}
+        function box(parent::Box{p,T,M,L,P,MB}, childindex::Integer) where {p,T,M,L,P,MB}
+            return new{p,T,M,L,P,MB}(parent.world, parent, childindex)
         end
 
         @noinline throw0(sd, mxd) = error("got split along dimension $sd, max allowed is $mxd")
@@ -241,7 +244,7 @@ mutable struct Box{p,T,M,L,P}
         return others
     end
 end
-Box{p}(world::World{T,P,M}) where {p,T,M,P} = Box{p,T,M,calcL(Val(p)),P}(world)
+Box{p}(world::World{T,P,M}, metabox=nothing) where {p,T,M,P} = Box{p,T,M,calcL(Val(p)),P,typeof(metabox)}(world, metabox)
 
 """
     root = Box{p}(world::World)
@@ -263,15 +266,15 @@ where `xp` is `position(parent)[splitdims]`.  For dimensions not
 listed in `splitdims`, the positions of these children are all
 identical to the parent evaluation point.
 """
-Box(parent::Box{p,T,M,L,P}, splitdims::NTuple{p,Integer}, xs::NTuple{p,Real}, metas::NTuple{L,Any}) where {p,T,M,L,P} =
-    Box{p,T,M,L,P}(parent, splitdims, xs, metas)
+Box(parent::Box{p,T,M,L,P,MB}, splitdims::NTuple{p,Integer}, xs::NTuple{p,Real}, metas::NTuple{L,Any}) where {p,T,M,L,P,MB} =
+    Box{p,T,M,L,P,MB}(parent, splitdims, xs, metas)
 
 Box(parent::Box{1,T,M,1}, splitdim::Integer, x::Real, meta) where {T,M} =
     Box(parent, (splitdim,), (x,), (meta,))
 
 # You can supply fewer than p dimensions, in which case we fill in
 # with fictive dimensions
-function Box(parent::Box{p,T,M,L,P}, splitdims::NTuple{k,Integer}, xs::NTuple{k,Real}, metas) where {p,T,M,k,L,P}
+function Box(parent::Box{p,T,M,L,P,MB}, splitdims::NTuple{k,Integer}, xs::NTuple{k,Real}, metas) where {p,T,M,k,L,P,MB}
     0 < k <= p || throw(DimensionMismatch("got $k dimensions, max allowed is $p"))
     nmeta = 2^k-1
     length(metas) == nmeta || error("got $(length(metas)) metadatas for $k split dimensions, need $nmeta")
@@ -290,7 +293,7 @@ function Box(parent::Box{p,T,M,L,P}, splitdims::NTuple{k,Integer}, xs::NTuple{k,
             return i == 0 ? parentmeta : metas[i]
         end
     end
-    return Box{p,T,M,L,P}(parent, splitdimspad, xspad, metaspad)
+    return Box{p,T,M,L,P,MB}(parent, splitdimspad, xspad, metaspad)
 end
 
 
@@ -315,7 +318,7 @@ degree(::Type{B}) where B<:Box{p} where p = p
 degree(box::Box) = degree(typeof(box))
 boxcoordtype(::Type{B}) where B<:Box{p,T} where {p,T} = T
 boxcoordtype(box::Box) = boxcoordtype(typeof(box))
-maxchildren(::Type{Box{p,T,M,L,P}}) where {p,T,M,L,P} = L+1
+maxchildren(::Type{Box{p,T,M,L,P,MB}}) where {p,T,M,L,P,MB} = L+1
 maxchildren(::Type{B}) where B<:Box{p} where p = 1<<p  # for partial type like Box{2}
 maxchildren(box::Box) = maxchildren(typeof(box))
 isnonleaf(box) = !isleaf(box)

--- a/src/types.jl
+++ b/src/types.jl
@@ -133,6 +133,7 @@ end
 Base.ndims(world::World) = length(world.position)
 baseposition(world::World{T}) where T = baseposition(T, world.position)
 
+Base.in(position::AbstractVector, world::World) = all(t->((x, l, u) = t; l <= x <= u), zip(position, world.lower, world.upper))
 
 ## Box
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1018,4 +1018,7 @@ end
         i += 1
         @test leaf.metabox == (-i, i)
     end
+    io = IOBuffer()
+    print_metabox(io, root)
+    @test String(take!(io)) == "Box10.0@[1.0, 1.0] with metadata (-1, 1)"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,6 +96,8 @@ end
     @test_throws ErrorException find_leaf_at(root, [1.2])
     @test length(root) == 5
     @test length(leaves(root)) == 3
+    @test position(leaf) ∈ root
+    @test position(leaf) ∈ leaf
 
     world = World([0], [Inf], [0], 10) # with infinite size
     root = Box{1}(world)
@@ -192,6 +194,8 @@ end
     @test myapproxeq(boxbounds(b1_1, 1), (2/3, 1.5))
     @test boxbounds(b1_1, 2) == (0, 1.5)
     @test myapproxeq(boxbounds(b1_1), [(2/3, 1.5), (0, 1.5)])
+
+    @test all(CoordinateSplittingPTrees.splittable, boxbounds(b1_1))
 
     geom = Dict()
     root = generate_randboxes(Box{1}, 2, 10, (args...)->record_geometry!(geom, args...))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -964,3 +964,19 @@ end
 └─ Box400@[10.0, 20.0, 1.0]
 """
 end
+
+@testset "Box metadata" begin
+    world = World([1, 1], 10.0)
+    root = Box{2}(world, (-1, 1))
+    local incrementor
+    let counter = 1
+        incrementor(box) = (counter += 1; (-counter,counter))
+    end
+    addpoint!(root, [2.0, 1.8], x->sum(x), incrementor)
+    @test root.metabox == (-1, 1)
+    i = 1
+    for leaf in leaves(root)
+        i += 1
+        @test leaf.metabox == (-i, i)
+    end
+end


### PR DESCRIPTION
Aside from adding box-specific metadata, this adds a lower-bound fitting model to specify the gradient and diagonal elements of the Hessian. This adds a dependency on Parametron.

It also supports `in` and adds some other conveniences.